### PR TITLE
Fix/biome responsive h2

### DIFF
--- a/src/components/biome.astro
+++ b/src/components/biome.astro
@@ -6,7 +6,7 @@ const { title, image, alt, description, features } = Astro.props;
 <header id={slugify(title)}>
   <img src={image} alt={alt} width="1280" height="720" loading="lazy" />
   <div>
-    
+
     <h2 class="retro-title">
       <a href=`#${slugify(title)}`>#</a>
       {title}
@@ -61,10 +61,12 @@ const { title, image, alt, description, features } = Astro.props;
       }
 
       > div {
+        container-type: inline-size;
         display: grid;
         max-inline-size: var(--size-content-3);
         margin: auto;
         gap: var(--size-3);
+        inline-size: 100%;
 
         @supports (animation-timeline: view()) {
           @media (prefers-reduced-motion: no-preference) {
@@ -76,7 +78,7 @@ const { title, image, alt, description, features } = Astro.props;
       }
 
       h2 {
-        font-size: clamp(5rem, 9vw, 7rem);
+        font-size: clamp(3rem, 19cqi, 7rem);
         margin-left: -0.4em;
         a {
           text-decoration: none;

--- a/src/components/biome.astro
+++ b/src/components/biome.astro
@@ -6,7 +6,6 @@ const { title, image, alt, description, features } = Astro.props;
 <header id={slugify(title)}>
   <img src={image} alt={alt} width="1280" height="720" loading="lazy" />
   <div>
-
     <h2 class="retro-title">
       <a href=`#${slugify(title)}`>#</a>
       {title}
@@ -76,7 +75,7 @@ const { title, image, alt, description, features } = Astro.props;
       }
 
       h2 {
-        font-size: clamp(3rem, 13vi,6.1rem);
+        font-size: clamp(3rem, 13vi, 6.1rem);
         margin-left: -0.4em;
         a {
           text-decoration: none;

--- a/src/components/biome.astro
+++ b/src/components/biome.astro
@@ -61,12 +61,10 @@ const { title, image, alt, description, features } = Astro.props;
       }
 
       > div {
-        container-type: inline-size;
         display: grid;
         max-inline-size: var(--size-content-3);
         margin: auto;
         gap: var(--size-3);
-        inline-size: 100%;
 
         @supports (animation-timeline: view()) {
           @media (prefers-reduced-motion: no-preference) {
@@ -78,7 +76,7 @@ const { title, image, alt, description, features } = Astro.props;
       }
 
       h2 {
-        font-size: clamp(3rem, 19cqi, 7rem);
+        font-size: clamp(3rem, 13vi,6.1rem);
         margin-left: -0.4em;
         a {
           text-decoration: none;


### PR DESCRIPTION
First of all, what a fun and joyful site you've made! 👏 And informative, it's a gold mine! 👌 

Noticed this issue with the `h2` element in `biome.astro` at the smallest and widest part of the clamp spectrum.
![image](https://github.com/user-attachments/assets/fd7ceb23-061f-47f6-bdfb-5dc161b53d3d)
![image](https://github.com/user-attachments/assets/4909a9a7-502b-4c11-9f2a-e87de0724636)

Changed the font size from `clamp(5rem, 9vw, 7rem)` to `clamp(3rem, 13vi, 6.1rem)` to accommodate "Developer Experience".

Anyhoo, don't want to make a big deal out of it - you can close this if you want 😅 